### PR TITLE
新增配置项：是否对URL进行编码

### DIFF
--- a/autofilm.py
+++ b/autofilm.py
@@ -128,7 +128,10 @@ def main(config_path: str):
         url = value["url"]
         username = value["username"]
         password = value["password"]
-        token = value["token"]
+        try:
+            token = value["token"]
+        except KeyError:
+            token = ""
 
         urls_queue = queue.Queue()
         files_queue = queue.Queue()

--- a/autofilm.py
+++ b/autofilm.py
@@ -4,9 +4,20 @@ import threading
 import requests
 import yaml
 import time
+import hmac
+import hashlib
+import base64
 from webdav3.client import Client
 
-def list_files(username: str, password: str, urls_queue:queue.Queue, files_queue:queue.Queue):
+def sign(secret_key: str, data: str):
+    if secret_key == "":
+        return ""
+    h = hmac.new(secret_key.encode(), digestmod=hashlib.sha256)
+    expire_time_stamp = str(0)
+    h.update((data + ":" + expire_time_stamp).encode())
+    return f"?sign={base64.urlsafe_b64encode(h.digest()).decode()}:0"
+
+def list_files(username: str, password: str, urls_queue: queue.Queue, files_queue: queue.Queue):
     while not urls_queue.empty():
         url = urls_queue.get()
         print(f"{threading.current_thread().name}——正在处理:{url}，剩余{urls_queue.qsize()}个URL待处理")
@@ -38,7 +49,7 @@ def list_files(username: str, password: str, urls_queue:queue.Queue, files_queue
                 files_queue.put(url + item)
     print(f"{threading.current_thread().name}处理完毕")
 
-def strm_file(url: str, output_path: str, filename: str):
+def strm_file(url: str, output_path: str, filename: str, file_absolute_path: str, token: str):
     strm_filename = filename.rsplit(".", 1)[0] + ".strm"
     local_path = os.path.join(output_path, strm_filename)
     if not os.path.exists(local_path):
@@ -46,20 +57,20 @@ def strm_file(url: str, output_path: str, filename: str):
             print(f"正在下载：{filename}")
             os.makedirs(os.path.dirname(local_path), exist_ok=True)
             with open(local_path, "wb") as file:
-                file.write((url.replace("/dav", "/d") + filename).encode())
+                file.write((url.replace("/dav", "/d") + filename + sign(token, file_absolute_path)).encode())
             print(f"{filename}处理成功")
         except Exception as e:
             print(f"{filename}处理失败，错误信息：{str(e)}")
     else:
         print(f"{filename}已存在，跳过处理")
 
-def download_file(url:str, output_path:str, filename:str):
+def download_file(url: str, output_path: str, filename: str, file_absolute_path: str, token: str):
     local_path = os.path.join(output_path, filename)
     if not os.path.exists(local_path):
         try:
             print(f"正在下载：{filename}")
             os.makedirs(os.path.dirname(local_path), exist_ok=True)
-            response = requests.get(url.replace("/dav", "/d") + filename)
+            response = requests.get(url.replace("/dav", "/d") + filename + sign(token, file_absolute_path))
             with open(local_path, "wb") as file:
                 file.write(response.content)
         except Exception as e:
@@ -67,7 +78,7 @@ def download_file(url:str, output_path:str, filename:str):
     else:
         print(f"{filename}已存在，跳过下载")
 
-def processing_file(output_path:str, url_base:str, files_queue:queue.Queue, subtitle:bool, img:bool, nfo:bool):
+def processing_file(output_path: str, url_base: str, files_queue: queue.Queue, subtitle: bool, img: bool, nfo: bool, token: str):
     video_format = ["mp4", "mkv", "flv", "avi", "wmv", "ts", "rmvb", "webm"]
     subtitle_format = ["ass", "srt", "ssa", "sub"]
     img_format = ["png", "jpg"]
@@ -79,30 +90,31 @@ def processing_file(output_path:str, url_base:str, files_queue:queue.Queue, subt
     while waite_number < waite_max:
         if not files_queue.empty():
             file_url = files_queue.get()
+            file_absolute_path = file_url[file_url.index("/dav") + 4:]
             print(f"{threading.current_thread().name}——正在处理:{file_url}，剩余{files_queue.qsize()}个文件待处理")
             filename = file_url.replace(url_base, "")
             if filename.lower().endswith(tuple(video_format)):
-                strm_file(url_base, output_path, filename)
+                strm_file(url_base, output_path, filename, file_absolute_path, token)
             elif filename.lower().endswith(tuple(subtitle_format)) & subtitle:
-                download_file(url_base, output_path, filename)
+                download_file(url_base, output_path, filename, file_absolute_path, token)
             elif filename.lower().endswith(tuple(img_format)) & img:
-                download_file(url_base, output_path, filename)
+                download_file(url_base, output_path, filename, file_absolute_path, token)
             elif filename.lower().endswith("nfo") & nfo:
-                download_file(url_base, output_path, filename)
+                download_file(url_base, output_path, filename, file_absolute_path, token)
         else:
             waite_number += 1
             print(f"files_queue列表为空，当前尝试次数：{waite_number}，共尝试{waite_max}次，{waite_time}秒后重试")
             time.sleep(waite_time)
     print(f"{threading.current_thread().name}处理完毕")
 
-def main(config_path:str):
+def main(config_path: str):
     with open(config_path, "r", encoding="utf-8") as file:
         config_data = yaml.safe_load(file)
     output_path = config_data["setting"]["output_path"]
     l_threads = config_data["setting"]["l_threads"]
     p_threads = config_data["setting"]["p_threads"]
 
-    print(f"{'='*65}\n输出目录：{output_path}\nlist_files线程数：{l_threads}\nprocessing_file线程数：{p_threads}\n{'='*65}")
+    print(f"{'=' * 65}\n输出目录：{output_path}\nlist_files线程数：{l_threads}\nprocessing_file线程数：{p_threads}\n{'=' * 65}")
     subtitle = config_data["setting"]["subtitle"]
     img = config_data["setting"]["img"]
     nfo = config_data["setting"]["nfo"]
@@ -111,13 +123,14 @@ def main(config_path:str):
     print(f"一共读取到{len(webdav_data)}个Webdav配置")
 
     round = 1
-    for key, value in  webdav_data.items():
+    for key, value in webdav_data.items():
         print(f"开始生成{key}Webdav服务器的Strm文件\n剩余{(len(webdav_data) - round)}个Webdav服务器未进行")
         url = value["url"]
         username = value["username"]
         password = value["password"]
+        token = value["token"]
 
-        urls_queue = queue.Queue() 
+        urls_queue = queue.Queue()
         files_queue = queue.Queue()
         urls_queue.put(url)
 
@@ -136,7 +149,7 @@ def main(config_path:str):
 
         for thread in range(p_threads):
             print(f"processing_file线程{thread}启动中")
-            t = threading.Thread(target=processing_file, args=(output_path, url, files_queue,subtitle, img, nfo), name=f"processing_file线程{thread}")
+            t = threading.Thread(target=processing_file, args=(output_path, url, files_queue, subtitle, img, nfo, token), name=f"processing_file线程{thread}")
             t.start()
             print(f"processing_file线程{thread}已启动，{processing_file_interval}秒后启动下一个线程")
             time.sleep(processing_file_interval)

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -19,8 +19,7 @@ webdav:
   电影A:
     url: https://al.chirmyram.com/dav/mov/电影/A/
     username: alist
-    password: alist
-    token: "alist-a1b2c3d4-12..."
+    password: alist                             # 或者直接不填写token项
   我的Alist:
     url: http://192.168.1.1:5244/dav/阿里云/
     username: admin

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -10,15 +10,19 @@ webdav:
     url: https://al.chirmyram.com/dav/ani/A/    # Webdav服务器URL
     username: alist                             # Webdav账号
     password: alist                             # Webdav密码
+    token: "alist-a1b2c3d4-56e7..."             # AList令牌 (仅当开启“签名所有”功能，或存储设置中启用了“启用签名”时，才需要填写)
   动漫B:
     url: https://al.chirmyram.com/dav/ani/B/
     username: alist
     password: alist
+    token: ""                                   # AList未启用签名时，设置为空字符串
   电影A:
-    url: https://al.chirmyram.com/dav/mov/电影/A
+    url: https://al.chirmyram.com/dav/mov/电影/A/
     username: alist
     password: alist
-   我的Alist:
+    token: "alist-a1b2c3d4-12..."
+  我的Alist:
     url: http://192.168.1.1:5244/dav/阿里云/
     username: admin
     password: adminadmin
+    token: "alist-a1b2c3d4-12..."

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -5,6 +5,7 @@ setting:
   subtitle: True            # 是否下载字幕
   img: False                # 是否下载图片
   nfo: True                 # 是否下载视频信息文件
+  url_encode: True          # 是否对生成的strm文件中的链接进行URL编码
 webdav:
   动漫A:                                        # 任意字符，用于标识Webdav服务器
     url: https://al.chirmyram.com/dav/ani/A/    # Webdav服务器URL


### PR DESCRIPTION
避免因链接含有非`RFC3986`标准的字符，继而造成请求出错，视频无法播放的问题。

更新了`autofilm.py`与`config.yaml.example`文件。

### URL编码前：

`strm`文件内容：

![image](https://github.com/Akimio521/AutoFilm/assets/42741874/56c1b912-3b90-4dcf-862a-eaf5ae03232d)


使用`Kodi`播放视频文件：

**无法播放**

![image](https://github.com/Akimio521/AutoFilm/assets/42741874/a781ef0b-0306-4604-b93a-2364983ea5ec)

---

### URL编码后：

`strm`文件内容：

![image](https://github.com/Akimio521/AutoFilm/assets/42741874/988d0d1f-418c-492e-920f-5ce3b91040ee)


使用`Kodi`播放视频文件：

**正常播放**

![image](https://github.com/Akimio521/AutoFilm/assets/42741874/70f1f878-631a-418f-bcfa-f3aba780e03e)

---

提交前忘记Sync了，所以有4个Commits，Sorry~ 🤯🤯🤯