### PR TITLE
Added sync_server Option and Translated Configuration Comments

### DIFF
--- a/app/modules/alist2strm/alist2strm.py
+++ b/app/modules/alist2strm/alist2strm.py
@@ -38,8 +38,22 @@ class Alist2Strm:
         """
         Initialize the Alist2Strm object.
 
+        :param url: Alist server URL, default is "http://localhost:5244"
+        :param username: Alist username, default is empty
+        :param password: Alist password, default is empty
+        :param source_dir: Source directory in Alist to synchronize, default is "/"
+        :param target_dir: Directory to output .strm files, default is current working directory
+        :param flatten_mode: If True, saves all .strm files in a single directory, default is False
+        :param subtitle: If True, downloads subtitle files, default is False
+        :param image: If True, downloads image files, default is False
+        :param nfo: If True, downloads .nfo files, default is False
+        :param mode: Strm mode (AlistURL/RawURL/AlistPath)
+        :param overwrite: If True, overwrite existing local files, default is False
+        :param other_ext: Custom extensions to download, separated by commas, default is empty
+        :param max_workers: Maximum number of concurrent workers
+        :param max_downloaders: Maximum number of simultaneous downloads
         :param sync_server: If True, synchronizes with the Alist server (deletes obsolete .strm files). Default is True.
-        Other parameters described previously...
+
         """
         self.url = url
         self.username = username

--- a/app/modules/alist2strm/alist2strm.py
+++ b/app/modules/alist2strm/alist2strm.py
@@ -32,25 +32,14 @@ class Alist2Strm:
         other_ext: str = "",
         max_workers: int = 50,
         max_downloaders: int = 5,
+        sync_server: bool = True,  # Nouveau paramètre
         **_,
     ) -> None:
         """
-        实例化 Alist2Strm 对象
+        Initialise l'objet Alist2Strm.
 
-        :param url: Alist 服务器地址，默认为 "http://localhost:5244"
-        :param username: Alist 用户名，默认为空
-        :param password: Alist 密码，默认为空
-        :param source_dir: 需要同步的 Alist 的目录，默认为 "/"
-        :param target_dir: strm 文件输出目录，默认为当前工作目录
-        :param flatten_mode: 平铺模式，将所有 Strm 文件保存至同一级目录，默认为 False
-        :param subtitle: 是否下载字幕文件，默认为 False
-        :param image: 是否下载图片文件，默认为 False
-        :param nfo: 是否下载 .nfo 文件，默认为 False
-        :param mode: Strm模式(AlistURL/RawURL/AlistPath)
-        :param overwrite: 本地路径存在同名文件时是否重新生成/下载该文件，默认为 False
-        :param other_ext: 自定义下载后缀，使用西文半角逗号进行分割，默认为空
-        :param max_worders: 最大并发数
-        :param max_downloaders: 最大同时下载
+        :param sync_server: Si True, synchronise avec le serveur Alist (supprime les fichiers .strm obsolètes). Par défaut True.
+        Autres paramètres décrits précédemment...
         """
         self.url = url
         self.username = username
@@ -58,7 +47,7 @@ class Alist2Strm:
         self.mode = mode
 
         self.source_dir = source_dir
-        self.target_dir = Path(target_dir)
+        self.target_dir = Path(target_dir).resolve()
 
         self.flatten_mode = flatten_mode
         if flatten_mode:
@@ -72,7 +61,9 @@ class Alist2Strm:
         if nfo:
             download_exts |= NFO_EXTS
         if other_ext:
-            download_exts |= frozenset(other_ext.lower().split(","))
+            download_exts |= frozenset(
+                ext.strip().lower() for ext in other_ext.split(",")
+            )
 
         self.download_exts = download_exts
         self.process_file_exts = VIDEO_EXTS | download_exts
@@ -81,40 +72,32 @@ class Alist2Strm:
         self.__max_workers = Semaphore(max_workers)
         self.__max_downloaders = Semaphore(max_downloaders)
 
+        # Initialize processed local paths set
+        self.processed_local_paths = set()
+
+        self.sync_server = sync_server  # Enregistrer le nouveau paramètre
+
     async def run(self) -> None:
         """
-        处理主体
+        Fonction principale de traitement.
         """
-
-        def filter(path: AlistPath) -> bool:
+        def filter_func(path: AlistPath) -> bool:
             if path.is_dir:
                 return False
 
             if not path.suffix.lower() in self.process_file_exts:
-                logger.debug(f"文件{path.name}不在处理列表中")
+                logger.debug(f"Fichier {path.name} non pris en charge.")
                 return False
 
-            if self.overwrite:
-                return True
+            return True  # Toujours True pour traiter tous les fichiers
 
-            local_path = self.__get_local_path(path)
-
-            if local_path.exists():
-                logger.debug(f"文件{local_path.name}已存在，跳过处理{path.path}")
-                return False
-
-            return True
-
-        if not self.mode in ["AlistURL", "RawURL", "AlistPath"]:
+        if self.mode not in ["AlistURL", "RawURL", "AlistPath"]:
             logger.warning(
-                f"Alist2Strm的模式{self.mode}不存在，已设置为默认模式AlistURL"
+                f"Mode '{self.mode}' non reconnu pour Alist2Strm. Utilisation du mode 'AlistURL' par défaut."
             )
             self.mode = "AlistURL"
 
-        if self.mode == "RawURL":
-            is_detail = True
-        else:
-            is_detail = False
+        is_detail = self.mode == "RawURL"
 
         async with self.__max_workers:
             async with ClientSession() as session:
@@ -125,19 +108,36 @@ class Alist2Strm:
                         self.url, self.username, self.password
                     ) as client:
                         async for path in client.iter_path(
-                            dir_path=self.source_dir, is_detail=is_detail, filter=filter
+                            dir_path=self.source_dir,
+                            is_detail=is_detail,
+                            filter=filter_func,
                         ):
-                            _create_task(self.__file_processer(path))
-            logger.info("Alist2Strm处理完成")
+                            _create_task(self.__file_processor(path))
+                logger.info("Traitement Alist2Strm terminé.")
+
+        # Si la synchronisation avec le serveur est activée
+        if self.sync_server:
+            # Étape de nettoyage : suppression des fichiers .strm obsolètes et de leurs fichiers associés
+            await self.__cleanup_local_files()
+            logger.info("Nettoyage des fichiers .strm obsolètes terminé.")
 
     @retry(Exception, tries=3, delay=3, backoff=2, logger=logger)
-    async def __file_processer(self, path: AlistPath) -> None:
+    async def __file_processor(self, path: AlistPath) -> None:
         """
-        异步保存文件至本地
+        Enregistre le fichier localement de manière asynchrone.
 
-        :param path: AlistPath 对象
+        :param path: Objet AlistPath
         """
         local_path = self.__get_local_path(path)
+
+        # Ajouter le chemin local aux chemins traités
+        self.processed_local_paths.add(local_path)
+
+        if not self.overwrite and local_path.exists():
+            logger.debug(
+                f"Fichier {local_path.name} déjà existant, saut du traitement de {path.path}."
+            )
+            return
 
         if self.mode == "AlistURL":
             content = path.download_url
@@ -146,41 +146,97 @@ class Alist2Strm:
         elif self.mode == "AlistPath":
             content = path.path
         else:
-            raise ValueError(f"AlistStrm未知的模式{self.mode}")
+            raise ValueError(f"Mode inconnu pour AlistStrm : {self.mode}")
 
         try:
-            _parent = local_path.parent
-            if not _parent.exists():
-                await to_thread(_parent.mkdir, parents=True, exist_ok=True)
+            parent_dir = local_path.parent
+            if not parent_dir.exists():
+                await to_thread(parent_dir.mkdir, parents=True, exist_ok=True)
 
-            logger.debug(f"开始处理{local_path}")
-            if local_path.suffix == ".strm":
+            logger.debug(f"Traitement de {local_path}...")
+            if local_path.suffix.lower() == ".strm":
                 async with async_open(local_path, mode="w", encoding="utf-8") as file:
                     await file.write(content)
-                logger.info(f"{local_path.name}创建成功")
+                logger.info(f"{local_path.name} créé avec succès.")
             else:
                 async with self.__max_downloaders:
                     async with async_open(local_path, mode="wb") as file:
-                        _write = file.write
                         async with self.session.get(path.download_url) as resp:
+                            if resp.status != 200:
+                                raise RuntimeError(
+                                    f"Échec du téléchargement de {path.download_url}, code d'état : {resp.status}"
+                                )
                             async for chunk in resp.content.iter_chunked(1024):
-                                await _write(chunk)
-                    logger.info(f"{local_path.name}下载成功")
+                                await file.write(chunk)
+                    logger.info(f"{local_path.name} téléchargé avec succès.")
+
         except Exception as e:
-            raise RuntimeError(f"{local_path}处理失败，详细信息：{e}")
+            raise RuntimeError(f"Échec du traitement de {local_path}, détails : {e}")
 
     def __get_local_path(self, path: AlistPath) -> Path:
         """
-        根据给定的 AlistPath 对象和当前的配置，计算出本地文件路径。
+        Calcule le chemin du fichier local en fonction de l'objet AlistPath et de la configuration actuelle.
+
+        :param path: Objet AlistPath
+        :return: Chemin du fichier local
         """
         if self.flatten_mode:
             local_path = self.target_dir / path.name
         else:
-            local_path = self.target_dir / path.path.replace(
-                self.source_dir, "", 1
-            ).lstrip("/")
+            # S'assurer que le chemin est relatif à source_dir
+            relative_path = path.path
+            if relative_path.startswith("/"):
+                relative_path = relative_path[1:]
+            local_path = self.target_dir / relative_path
 
         if path.suffix.lower() in VIDEO_EXTS:
             local_path = local_path.with_suffix(".strm")
 
         return local_path
+
+    async def __cleanup_local_files(self) -> None:
+        """
+        Supprime les fichiers .strm locaux et leurs fichiers associés qui n'ont pas été traités lors de l'exécution actuelle.
+        """
+        logger.info("Début du nettoyage des fichiers .strm obsolètes.")
+
+        # Collecter tous les fichiers dans le répertoire cible
+        if self.flatten_mode:
+            # Ne regarder que dans target_dir
+            all_local_files = [f for f in self.target_dir.iterdir() if f.is_file()]
+        else:
+            # Parcourir target_dir récursivement
+            all_local_files = [
+                f for f in self.target_dir.rglob("*") if f.is_file()
+            ]
+
+        files_to_delete = set(all_local_files) - self.processed_local_paths
+
+        # Supprimer les fichiers et leurs fichiers associés
+        for file_path in files_to_delete:
+            associated_files = self.__get_associated_files(file_path)
+            for file in [file_path] + associated_files:
+                try:
+                    if file.exists():
+                        await to_thread(file.unlink)
+                        logger.info(f"Fichier obsolète supprimé : {file}")
+                except Exception as e:
+                    logger.error(f"Échec de la suppression du fichier {file} : {e}")
+
+    def __get_associated_files(self, file_path: Path) -> list[Path]:
+        """
+        Récupère les fichiers associés (.nfo, sous-titres, etc.) pour un fichier donné.
+
+        :param file_path: Chemin du fichier
+        :return: Liste des chemins des fichiers associés
+        """
+        associated_files = []
+
+        # Définir les extensions associées en fonction de la configuration
+        associated_exts = list(self.download_exts)
+
+        for ext in associated_exts:
+            associated_file = file_path.with_suffix(ext)
+            associated_files.append(associated_file)
+
+        return associated_files

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -1,49 +1,51 @@
 Settings:
-  DEV: False                          # 开发者模式(可选，默认 False)
+  DEV: False                          # Developer mode (optional, default False)
 
 Alist2StrmList:
-  - id: 动漫                          # 标识 ID
-    cron: 0 20 * * *                  # 后台定时任务 Crontable 表达式
-    url: https://alist.akimio.top     # Alist 服务器地址
-    username: admin                   # Alist 用户名
-    password: adminadmin              # Alist 密码
-    source_dir: /ani/                 # Alist 服务器上文件夹路径
-    target_dir: D:\media\             # 输出路径
-    flatten_mode: False               # 平铺模式，开启后 subtitle、image、nfo 强制关闭(可选，默认 False)
-    subtitle: False                   # 是否下载字幕文件（可选，默认 False）
-    image: False                      # 是否下载图片文件（可选，默认 False）
-    nfo: False                        # 是否下载 .nfo 文件（可选，默认 False）
-    mode: AlistURL                    # Strm文件中的内容（可选项：AlistURL、RawURL、AlistPath）
-    overwrite: False                  # 覆盖模式，本地路径存在同名文件时是否重新生成/下载该文件（可选，默认 False）
-    other_ext:                        # 自定义下载后缀，使用西文半角逗号进行分割，（可选，默认为空）
-    max_workers: 50                   # 最大并发数，减轻对 Alist 服务器的负载（可选，默认 50）
-    max_downloaders: 5                 # 最大同时下载文件数（可选，默认 5）
-    
-  - id: 电影
-    cron: 0 0 7 * *
+  - id: Anime                         # Identifier ID
+    cron: 0 20 * * *                  # Background scheduled task Crontab expression
+    url: https://alist.akimio.top     # Alist server address
+    username: admin                   # Alist username
+    password: adminadmin              # Alist password
+    source_dir: /ani/                 # Directory path on Alist server
+    target_dir: D:\media\             # Output path
+    flatten_mode: False               # Flatten mode; when enabled, subtitle, image, nfo are forcibly turned off (optional, default False)
+    subtitle: False                   # Whether to download subtitle files (optional, default False)
+    image: False                      # Whether to download image files (optional, default False)
+    nfo: False                        # Whether to download .nfo files (optional, default False)
+    mode: AlistURL                    # Content in .strm files (options: AlistURL, RawURL, AlistPath)
+    overwrite: False                  # Overwrite mode; whether to regenerate/download the file when a file with the same name exists locally (optional, default False)
+    sync_server: True                 # Synchronize with the server (delete obsolete .strm files) (optional, default True)
+    other_ext:                        # Custom download extensions, separated by commas (optional, default empty)
+    max_workers: 50                   # Maximum concurrency to reduce the load on the Alist server (optional, default 50)
+    max_downloaders: 5                # Maximum number of simultaneous file downloads (optional, default 5)
+
+  - id: Movies
+    cron: 0 0 7 * *                   # Background scheduled task Crontab expression
     url: http://alist.example2.com:5244
     username: alist
     password: alist
-    source_dir: /网盘/115/电影
-    target_dir: /media/my_video 
+    source_dir: /Drive/115/Movies     # Directory path on Alist server
+    target_dir: /media/my_video       # Output path
     flatten_mode: False 
     subtitle: False
     image: False
     nfo: False
     mode: RawURL
     overwrite: False
+    sync_server: True
     other_ext: zip,md
     max_workers: 5
 
 Ani2AlistList:
-  - id: 新番追更                           # 标识 ID
-    cron: 20 12 * * *                     # 后台定时任务 Crontable 表达式
-    url: https://127.0.0.1:5244           # Alist 服务器地址
-    username: admin                       # Alist 用户名（需管理员权限）
-    password: myalist                     # Alist 密码
-    target_dir: /视频/动漫/新番            # Alist 地址树存储器路径，若存储器不存在将自动创建（可选，默认/Anime）
-    rss_update: False                     # 使用 RSS 订阅更新最新番剧，启用后忽视传入的 year 和 month（可选，默认为 True）
-    year: 2024                            # 动漫季度-年份，仅支持 2019-1 及以后更新的番剧（可选，默认使用当前日期）
-    month: 7                              # 动漫季度-月份，仅支持 2019-1 及以后更新的番剧（可选，默认使用当前日期）
-    src_domain: aniopen.an-i.workers.dev  # ANI Open 项目域名（可选，默认为 aniopen.an-i.workers.dev）
-    rss_domain: api.ani.rip               # ANI Open 项目 RSS 订阅域名（可选，默认为 api.ani.rip） 
+  - id: New Anime Updates             # Identifier ID
+    cron: 20 12 * * *                 # Background scheduled task Crontab expression
+    url: https://127.0.0.1:5244       # Alist server address
+    username: admin                   # Alist username (requires administrator privileges)
+    password: myalist                 # Alist password
+    target_dir: /Videos/Anime/New     # Alist storage path in the address tree; if the storage does not exist, it will be automatically created (optional, default /Anime)
+    rss_update: False                 # Use RSS subscription to update the latest anime; when enabled, ignores the provided year and month (optional, default True)
+    year: 2024                        # Anime season - year, supports only anime updated after 2019-1 (optional, default uses current date)
+    month: 7                          # Anime season - month, supports only anime updated after 2019-1 (optional, default uses current date)
+    src_domain: aniopen.an-i.workers.dev  # ANI Open project domain name (optional, default aniopen.an-i.workers.dev)
+    rss_domain: api.ani.rip               # ANI Open project RSS subscription domain name (optional, default api.ani.rip)


### PR DESCRIPTION
**Summary:**

This pull request introduces the `sync_server` option to the Alist2Strm script, allowing users to control whether the script synchronizes with the Alist server and deletes obsolete `.strm` files. Additionally, all comments in the configuration file have been translated into English for better readability.

**Changes:**

**Added `sync_server` Option:**

- **Purpose:** Enables or disables synchronization with the Alist server.
- **Implementation:**
  - Added `sync_server: bool = True` parameter to the `__init__` method of the `Alist2Strm` class.
  - Updated the `run` method to check `self.sync_server`. If `True`, it executes the `__cleanup_local_files` method to remove obsolete files. If `False`, it skips this step.

**Translated Configuration File Comments:**

- All comments in the configuration file have been translated from Chinese to English.

**Usage:**

To enable synchronization (default behavior):

```yaml
sync_server: True
```

To disable synchronization (keep obsolete `.strm` files):

```yaml
sync_server: False
```


**Benefits:**

- **Flexibility:** Users can now choose whether to synchronize with the server on a per-configuration basis.
- **Accessibility:** English comments make the configuration file easier to understand for a wider audience.

