### PR TITLE
Add sync_ignore option to Alist2Strm

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -18,6 +18,7 @@ Alist2StrmList:
     overwrite: False                  # 覆盖模式，本地路径存在同名文件时是否重新生成/下载该文件（可选，默认 False）
     sync_server: True                 # 是否同步服务器（可选，默认为 True）
     other_ext:                        # 自定义下载后缀，使用西文半角逗号进行分割，（可选，默认为空）
+    sync_ignore: nfo,jpg              # 同步时忽略的文件后缀，使用西文半角逗号进行分割（可选，默认为空）
     max_workers: 50                   # 最大并发数，减轻对 Alist 服务器的负载（可选，默认 50）
     max_downloaders: 5                # 最大同时下载文件数（可选，默认 5）
     
@@ -36,6 +37,7 @@ Alist2StrmList:
     mode: RawURL
     overwrite: False
     sync_server: True
+    sync_ignore:
     other_ext: zip,md
     max_workers: 5
 

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -17,8 +17,10 @@ Alist2StrmList:
     mode: AlistURL                    # Strm 文件中的内容（可选项：AlistURL、RawURL、AlistPath）
     overwrite: False                  # 覆盖模式，本地路径存在同名文件时是否重新生成/下载该文件（可选，默认 False）
     sync_server: True                 # 是否同步服务器（可选，默认为 True）
+    sync_ignore:                      # 同步时忽略的文件正则表达式列表（可选，默认为空）
+      - .*\.nfo$                      # 忽略所有 .nfo 文件
+      - .*\.jpg$                      # 忽略所有 .jpg 文件
     other_ext:                        # 自定义下载后缀，使用西文半角逗号进行分割，（可选，默认为空）
-    sync_ignore: nfo,jpg              # 同步时忽略的文件后缀，使用西文半角逗号进行分割（可选，默认为空）
     max_workers: 50                   # 最大并发数，减轻对 Alist 服务器的负载（可选，默认 50）
     max_downloaders: 5                # 最大同时下载文件数（可选，默认 5）
     


### PR DESCRIPTION
Description:

This PR adds a new configuration option sync_ignore to the Alist2Strm module that allows users to specify file extensions that should be ignored during server synchronization.

Currently, when sync_server is enabled, all local files that don't exist on the Alist server are deleted. This new feature allows users to protect certain local files (like NFO files or images) from being deleted during synchronization, even if they don't exist on the remote server.

Benefits:

Preserves local metadata files (NFO)
Keeps local artwork (JPG, PNG)
Allows for hybrid setups where some files are managed locally while others sync with Alist
More flexible synchronization options
This enhancement is particularly useful for users who maintain local metadata files while using Alist for media storage.