### PR TITLE
添加 .m2ts 视频文件格式支持

### DIFF
--- a/app/extensions/exts.py
+++ b/app/extensions/exts.py
@@ -1,12 +1,13 @@
 from typing import Final
 
-VIDEO_EXTS: Final = frozenset(
-    (".mp4", ".mkv", ".flv", ".avi", ".wmv", ".ts", ".rmvb", ".webm", "wmv", ".mpg")
-)  # 视频文件后缀
-EXTENDED_VIDEO_EXTS: Final = VIDEO_EXTS.union((".strm",))  # 扩展视频文件后缀
+VIDEO_EXTS: Final = frozenset((
+    ".mp4", ".mkv", ".flv", ".avi", ".wmv", ".ts", ".rmvb", ".webm", "wmv", ".mpg", ".m2ts"
+))  # 视频文件后缀
+EXTENDED_VIDEO_EXTS: Final = VIDEO_EXTS.union(frozenset((".strm",)))  # 扩展视频文件后缀
 
 SUBTITLE_EXTS: Final = frozenset((".ass", ".srt", ".ssa", ".sub"))  # 字幕文件后缀
 
 IMAGE_EXTS: Final = frozenset((".png", ".jpg"))
 
 NFO_EXTS: Final = frozenset((".nfo",))
+


### PR DESCRIPTION
# 添加 .m2ts 视频文件格式支持

## 功能描述
此 PR 添加了对 `.m2ts` 视频文件格式的支持。`.m2ts` 是蓝光光盘（BDMV）中常用的视频文件格式，添加此支持可以让 AutoFilm 正确识别和处理蓝光原盘中的视频文件。

## 修改内容
- 在 `app/extensions/exts.py` 中将 `.m2ts` 添加到 `VIDEO_EXTS` 集合中
- 优化了 `EXTENDED_VIDEO_EXTS` 的定义方式，使用 `frozenset` 包装 `.strm` 扩展名

## 测试结果
已验证 AutoFilm 可以正确识别 `.m2ts` 文件作为视频文件。

## 相关问题
这是支持 BDMV 结构的第一步，为后续完整的 BDMV 结构处理功能奠定基础。
