### PR TITLE
修复 NoneType is not callable 错误

### DIFF
--- a/app/modules/alist2strm/alist2strm.py
+++ b/app/modules/alist2strm/alist2strm.py
@@ -155,7 +155,7 @@ class Alist2Strm:
                 dir_path=self.source_dir,
                 wait_time=self.wait_time,
                 is_detail=is_detail,
-                filter=filter,
+                # 使用默认的 filter 函数 (lambda x: True)，不要传递 None
             ):
                 tg.create_task(self.__file_processer(path))
 


### PR DESCRIPTION
# 修复 NoneType is not callable 错误

## 问题描述
在使用 `iter_path` 方法时，如果传入 `filter=None` 参数，会导致 `NoneType is not callable` 错误。这是因为 `iter_path` 方法内部尝试调用 `filter` 作为函数，但当它为 `None` 时会引发类型错误。

## 修改内容
- 在 `app/modules/alist2strm/alist2strm.py` 文件中，移除了 `iter_path` 调用中的 `filter=filter` 参数
- 添加了注释说明使用默认的 filter 函数 (lambda x: True)，而不是传递 None

## 修复效果
此修复可以防止在处理文件时出现 `NoneType is not callable` 错误，提高了程序的稳定性。

## 技术细节
当不指定 `filter` 参数时，`iter_path` 方法会使用默认的过滤函数 `lambda x: True`，这个函数会接受所有项目。这比传递 `None` 更安全，因为它避免了类型错误。
