### PR TITLE
添加了ENV PYTHONPATH=/app环境变量设置

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN apk del build-base linux-headers && \
 FROM python:3.12.7-alpine
 
 ENV TZ=Asia/Shanghai
+ENV PYTHONPATH=/app
+
 VOLUME ["/config", "/logs", "/media"]
 
 RUN apk update && \


### PR DESCRIPTION
在Dockerfile中添加了ENV PYTHONPATH=/app环境变量设置
修复了由于PR #121 更改为相对路径后导致的无法打包镜像