### PR TITLE
修复emby多文件夹海报无法下载bug

### DIFF
--- a/app/modules/libraryposter/poster.py
+++ b/app/modules/libraryposter/poster.py
@@ -93,7 +93,7 @@ class LibraryPoster:
 
         return resp.json()["Items"]
 
-    async def get_library_items(#修改的函数
+    async def get_library_items(
         self,
         library_id: str,
         user_id: str = "",
@@ -122,7 +122,7 @@ class LibraryPoster:
             )
             return []
 
-        while len(all_items) < 15 and max_depth <= 5:
+        while len(all_items) < 15 and max_depth <= 5:#如果当前目录获取的海报小于15张，那么增加一级文件夹层级获取更多海报，最多5个级别
             all_items = await self.fetch_items(library_id, user_id, max_depth=max_depth)
             max_depth += 1
 


### PR DESCRIPTION
1.修复emby媒体库拥有多个文件路径时海报无法下载bug
2.修复emby单文件夹有多个子目录时获取的海报（获取到的海报和子文件夹数目相同）过少bug

Closes #139